### PR TITLE
[WIP]active hash のバージョン変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,4 +68,4 @@ gem 'haml-rails'
 
 gem 'erb2haml'
 
-gem 'active_hash'
+gem 'active_hash', '~> 1.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_hash (2.2.1)
-      activesupport (>= 5.0.0)
+    active_hash (1.5.3)
+      activesupport (>= 2.2.2)
     activejob (5.0.7.1)
       activesupport (= 5.0.7.1)
       globalid (>= 0.3.6)
@@ -218,7 +218,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_hash
+  active_hash (~> 1.5.3)
   byebug
   capistrano
   capistrano-bundler
@@ -246,4 +246,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
#What
Active hashをRuby 2.3.1用のgemに変更する。

#Why
本番環境とバージョンを合わせるため